### PR TITLE
README: add a line mentioning mechanize

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ https://github.com/HiOA-ABI/nikita-noark5-core .
 
 The latest version of the test scripts can be found in
 https://github.com/petterreinholdtsen/noark5-tester
+
+You might need to install `python-mechanize` if you don't already have it
+installed.


### PR DESCRIPTION
This would have helped me earlier today when I tried installing
mechanize via pip vs. the default OS package manager.