### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:jessie
+
+COPY . /srv/app
+WORKDIR /srv/app
+
+RUN apt-get update
+RUN apt-get install -y python-mechanize
+
+ENTRYPOINT ["/usr/bin/python", "runtest"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# docker build says: reference format: repository name must be lowercase
+project ?=nikita5/noark5-tester
+
+docker:
+	docker build -t ${project} .
+docker_deploy: docker docker_push
+	echo "Pushed to docker, https://hub.docker.com/r/${project}"
+docker_run: docker
+	docker run --network="host" --add-host=$(shell hostname):127.0.0.1 ${project}
+docker_push:
+	docker push ${project}
+docker_tail:
+	docker logs `docker ps | grep ${project} | awk ' { print $$1 } '`


### PR DESCRIPTION
This makes it easy to deploy on systems where you have docker[0] installed and
would like to restrict the number of new packages installed on your host OS. The
container is setup to execute the runtest on start.

Now you can get elasticsearch, the application and the runtest up:

```bash
$ docker run -d -p 9200:9200 elasticsearch:2.4.4 -Des.network.host=0.0.0.0
$ curl http://localhost:9200
$ curl -XPUT 'localhost:9200/_template/replicate_template' -d '{ "template" : "*", "settings" : {"number_of_replicas" : 0 } }'
$ docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/nikita-noark5-core
$ docker run --network="host" --add-host=`hostname`:127.0.0.1 nikita5/noark5-tester
```

[0]: https://www.docker.com/