### PR TITLE
Open file in "read binary" mode when uploading

### DIFF
--- a/import-uttrekk
+++ b/import-uttrekk
@@ -850,7 +850,7 @@ FIXME flag inaccurate guesses somehow
         if '\\' in filepath:
             filepath = filepath.replace('\\', '/')
         try:
-            with open(filepath) as content:
+            with open(filepath, 'rb') as content:
                 size = os.path.getsize(filepath)
                 # FIXME Workaround for bruken runtime and nikita 2020-01-13
                 if 'format' in info:


### PR DESCRIPTION
With Python 3, the POST to upload a document causes an EOFException in Nikita.
This appears to be due to the fact that the script was opening the file to be uploaded 
in text-mode, which probably led to a corrupt request.